### PR TITLE
Remove test for /dev/sev on sevctl session test

### DIFF
--- a/test_sevctl.py
+++ b/test_sevctl.py
@@ -266,9 +266,6 @@ def test_sevctl_ok_ok(sevctl_bin, dev_sev_r, dev_sev_w):
     assert res.returncode == 0
 
 def test_sevctl_session_ok(sevctl_bin, dev_sev_r):
-    if not dev_sev_r:
-        pytest.skip("unable to open /dev/sev")
-
     pdhf = f"session-test-pdh.cert"
 
     res = subprocess.run([sevctl_bin, "session", pdhf, "3"])


### PR DESCRIPTION
sevctl session does not rely on /dev/sev being readable or writable. The
subcommand doesn't interact with the device node.

Signed-off-by: Tyler Fanelli <tfanelli@redhat.com>